### PR TITLE
Combine latex examples into true false questions

### DIFF
--- a/plane_true_false_part_A.tex
+++ b/plane_true_false_part_A.tex
@@ -11,37 +11,25 @@
 
 Câu 1: Chọn các mệnh đề đúng.
 
-a) Góc giữa mặt phẳng $(P): -x + 3y - z + 5 = 0$ và mặt phẳng $(Oxy)$ bằng $ 102^\circ $.
+*a) Với $m = \frac{-10}{3}$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): -2x + 3y - 2z -5 = 0.
 
-*b) Góc giữa mặt phẳng $(P): y + z -2 = 0$ và mặt phẳng $(Oxy)$ bằng $ 45^\circ $.
+*b) Gọi B là điểm đối xứng của A(1;1;-1) qua mặt phẳng (P): -2x - 3y + 2z -2 = 0. Khi đó độ dài $AB$ bằng $ \dfrac{18}{\sqrt{17}} $.
 
-*c) Góc giữa hai mặt phẳng $(P): -2x - 2y - z + 1 = 0$ và $(Q): -x - 3y + 3z + 4 = 0$ bằng $ 68^\circ $.
+*c) Tồn tại điểm $M(0;0;5.10)$ sao cho $d(M,(P)) = d(M,A)$ với $A(-3;1;3)$ và $(P): 2x + y - 4z + 3 = 0$.
 
-*d) Góc giữa mặt phẳng $(P): -3x + y + 3z = 0$ và mặt phẳng $(Oxy)$ bằng $ 47^\circ $.
+*d) Khoảng cách từ điểm A(4;-2;-4) đến mặt phẳng (P): -3x - 5y + 5z -4 = 0 bằng $ \dfrac{26}{\sqrt{59}} $.
 
 
 
 Câu 2: Chọn các mệnh đề đúng.
 
-*a) Với $m = -2$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): 3x - 2y + 2z + 6 = 0.
+*a) Góc giữa hai mặt phẳng $(P): -3x + 2y - z + 1 = 0$ và $(Q): -3x + 3z -6 = 0$ bằng $ 68^\circ $.
 
-b) Điểm M(-3;-1;-1) thuộc mặt phẳng (P): 4x - y - 4z + 3 = 0.
+*b) Khoảng cách từ điểm A(3;2;1) đến mặt phẳng (P): -4x + 4y - 2z -1 = 0 bằng $ \dfrac{7}{\sqrt{36}} $.
 
-c) Với $m = -2$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): -3x - y + 3z -2 = 0.
+c) Điểm M(-1;-2;-12) thuộc mặt phẳng (P): x - 4y + z + 6 = 0.
 
-d) Điểm M(3;-3;-5) thuộc mặt phẳng (P): -x + 2y - 2z -2 = 0.
-
-
-
-Câu 3: Chọn các mệnh đề đúng.
-
-*a) Góc giữa mặt phẳng $(P): -3x + 2y - 3z -4 = 0$ và mặt phẳng $(Oxy)$ bằng $ 50^\circ $.
-
-b) Góc giữa hai mặt phẳng $(P): -3x - y -6 = 0$ và $(Q): -x - 2z + 3 = 0$ bằng $ 80^\circ $.
-
-*c) Góc giữa hai mặt phẳng $(P): 2x + 3y + 2z + 1 = 0$ và $(Q): 3x + 3y + z -2 = 0$ bằng $ 19^\circ $.
-
-*d) Góc giữa hai mặt phẳng $(P): x - 3y + 3z + 3 = 0$ và $(Q): 2x + 2y + z + 3 = 0$ bằng $ 86^\circ $.
+d) Tồn tại điểm $M(0;0;-1)$ sao cho $d(M,(P)) = d(M,A)$ với $A(0;2;1)$ và $(P): -4x - 2y + 3z + 1 = 0$.
 
 
 

--- a/plane_true_false_part_A.tex
+++ b/plane_true_false_part_A.tex
@@ -1,0 +1,48 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage{amsmath,amssymb}
+\usepackage{geometry}
+\geometry{a4paper, margin=1in}
+\usepackage{polyglossia}
+\setmainlanguage{vietnamese}
+\setmainfont{Times New Roman}
+\begin{document}
+
+\section*{Các bài toán về các thông số liên quan - Đúng/Sai}
+
+Câu 1: Chọn các mệnh đề đúng.
+
+a) Góc giữa mặt phẳng $(P): -x + 3y - z + 5 = 0$ và mặt phẳng $(Oxy)$ bằng $ 102^\circ $.
+
+*b) Góc giữa mặt phẳng $(P): y + z -2 = 0$ và mặt phẳng $(Oxy)$ bằng $ 45^\circ $.
+
+*c) Góc giữa hai mặt phẳng $(P): -2x - 2y - z + 1 = 0$ và $(Q): -x - 3y + 3z + 4 = 0$ bằng $ 68^\circ $.
+
+*d) Góc giữa mặt phẳng $(P): -3x + y + 3z = 0$ và mặt phẳng $(Oxy)$ bằng $ 47^\circ $.
+
+
+
+Câu 2: Chọn các mệnh đề đúng.
+
+*a) Với $m = -2$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): 3x - 2y + 2z + 6 = 0.
+
+b) Điểm M(-3;-1;-1) thuộc mặt phẳng (P): 4x - y - 4z + 3 = 0.
+
+c) Với $m = -2$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): -3x - y + 3z -2 = 0.
+
+d) Điểm M(3;-3;-5) thuộc mặt phẳng (P): -x + 2y - 2z -2 = 0.
+
+
+
+Câu 3: Chọn các mệnh đề đúng.
+
+*a) Góc giữa mặt phẳng $(P): -3x + 2y - 3z -4 = 0$ và mặt phẳng $(Oxy)$ bằng $ 50^\circ $.
+
+b) Góc giữa hai mặt phẳng $(P): -3x - y -6 = 0$ và $(Q): -x - 2z + 3 = 0$ bằng $ 80^\circ $.
+
+*c) Góc giữa hai mặt phẳng $(P): 2x + 3y + 2z + 1 = 0$ và $(Q): 3x + 3y + z -2 = 0$ bằng $ 19^\circ $.
+
+*d) Góc giữa hai mặt phẳng $(P): x - 3y + 3z + 3 = 0$ và $(Q): 2x + 2y + z + 3 = 0$ bằng $ 86^\circ $.
+
+
+
+\end{document}

--- a/plane_true_false_part_B.tex
+++ b/plane_true_false_part_B.tex
@@ -11,37 +11,25 @@
 
 Câu 1: Chọn các mệnh đề đúng.
 
-*a) Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$.
+a) Với M(1;2;3), mặt phẳng (P) để $T$ nhỏ nhất có dạng $ax+by+cz+d=0$ với $a=b=c=0$.
 
-*b) Với M(1;2;3), mặt phẳng (P) để $T=\dfrac{1}{OA^2}+\dfrac{1}{OB^2}+\dfrac{1}{OC^2}$ nhỏ nhất có dạng $x+ay+bz+c=0$.
+b) Cho điểm M(-3;2;4). Mặt phẳng song song với (ABC) có phương trình $3x-6y-4z+12=0$.
 
-*c) Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$.
+*c) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 6 = 0$.
 
-*d) Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$.
+d) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $2x+3y+6z-6=0$.
 
 
 
 Câu 2: Chọn các mệnh đề đúng.
 
-*a) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
+a) Cho điểm M(-3;2;4). Mặt phẳng song song với (ABC) có phương trình $3x-6y-4z+12=0$.
 
-*b) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 6 = 0$.
-
-*c) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
-
-*d) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
-
-
-
-Câu 3: Chọn các mệnh đề đúng.
-
-*a) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
-
-b) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $2x+3y+6z-6=0$.
+*b) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
 
 c) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 7 = 0$.
 
-d) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 7 = 0$.
+d) Với M(1;2;3), mặt phẳng (P) để $T$ nhỏ nhất có dạng $ax+by+cz+d=0$ với $a=b=c=0$.
 
 
 

--- a/plane_true_false_part_B.tex
+++ b/plane_true_false_part_B.tex
@@ -1,0 +1,48 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage{amsmath,amssymb}
+\usepackage{geometry}
+\geometry{a4paper, margin=1in}
+\usepackage{polyglossia}
+\setmainlanguage{vietnamese}
+\setmainfont{Times New Roman}
+\begin{document}
+
+\section*{Các bài toán về viết phương trình mặt phẳng - Đúng/Sai}
+
+Câu 1: Chọn các mệnh đề đúng.
+
+*a) Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$.
+
+*b) Với M(1;2;3), mặt phẳng (P) để $T=\dfrac{1}{OA^2}+\dfrac{1}{OB^2}+\dfrac{1}{OC^2}$ nhỏ nhất có dạng $x+ay+bz+c=0$.
+
+*c) Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$.
+
+*d) Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$.
+
+
+
+Câu 2: Chọn các mệnh đề đúng.
+
+*a) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
+
+*b) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 6 = 0$.
+
+*c) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
+
+*d) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
+
+
+
+Câu 3: Chọn các mệnh đề đúng.
+
+*a) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$.
+
+b) Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $2x+3y+6z-6=0$.
+
+c) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 7 = 0$.
+
+d) Phương trình mặt phẳng qua A(1;0;0), B(0;-2;0), C(0;0;3) là $(P): -6x + 3y - 2z + 7 = 0$.
+
+
+
+\end{document}

--- a/plane_true_false_part_C.tex
+++ b/plane_true_false_part_C.tex
@@ -1,0 +1,48 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage{amsmath,amssymb}
+\usepackage{geometry}
+\geometry{a4paper, margin=1in}
+\usepackage{polyglossia}
+\setmainlanguage{vietnamese}
+\setmainfont{Times New Roman}
+\begin{document}
+
+\section*{Tương giao mặt phẳng và mặt cầu - Đúng/Sai}
+
+Câu 1: Chọn các mệnh đề đúng.
+
+a) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
+
+*b) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+*c) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+d) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
+
+
+
+Câu 2: Chọn các mệnh đề đúng.
+
+*a) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+*b) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+*c) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+*d) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+
+
+Câu 3: Chọn các mệnh đề đúng.
+
+a) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
+
+b) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
+
+*c) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+*d) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+
+
+
+\end{document}

--- a/plane_true_false_part_C.tex
+++ b/plane_true_false_part_C.tex
@@ -11,11 +11,11 @@
 
 Câu 1: Chọn các mệnh đề đúng.
 
-a) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
+a) Hình cầu tâm I(0;-2;1) tiếp xúc với mặt phẳng $(P): 4x + 3y - 2z + 1 = 0$ có bán kính $\dfrac{8}{\sqrt{29}}$.
 
-*b) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+*b) Mặt phẳng tiếp xúc với mặt cầu tâm I(-2;-1;-1) bán kính 5 tại M(3;-1;-1) có phương trình $(P): 5x -15 = 0$.
 
-*c) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+*c) Tồn tại mặt phẳng $(Q)$ song song với $(P): x + 2y - z -7 = 0$ và tiếp xúc với mặt cầu $x^2+y^2+z^2+4x+6y+-2z+-5=0$ có dạng $(Q): x + 2y - z + 20 = 0$.
 
 d) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
 
@@ -23,25 +23,13 @@ d) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến
 
 Câu 2: Chọn các mệnh đề đúng.
 
-*a) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+*a) Mặt phẳng tiếp xúc với mặt cầu tâm I(-2;-2;-1) bán kính 4 tại M(2;-2;-1) có phương trình $(P): 4x -8 = 0$.
 
-*b) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
-
-*c) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
-
-*d) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
-
-
-
-Câu 3: Chọn các mệnh đề đúng.
-
-a) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
-
-b) Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$.
+*b) Hình cầu tâm I(0;-2;1) tiếp xúc với mặt phẳng $(P): 4x + 3y - 2z + 1 = 0$ có bán kính $\dfrac{7}{\sqrt{29}}$.
 
 *c) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
 
-*d) Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung.
+*d) Tồn tại mặt phẳng $(Q)$ song song với $(P): x + 2y - 2z + 9 = 0$ và tiếp xúc với mặt cầu $x^2+y^2+z^2+2x+-6y+6z+-10=0$ có dạng $(Q): x + 2y - 2z + 5 = 0$.
 
 
 

--- a/src/plane_true_false_part_A.py
+++ b/src/plane_true_false_part_A.py
@@ -357,13 +357,25 @@ PART_A_GROUPS: List[List] = [
 
 
 def generate_question(question_number: int) -> str:
-    # Pick a group randomly and sample four propositions from it (allow repeats of type with different params)
-    group = random.choice(PART_A_GROUPS)
-    propositions: List[Dict[str, str]] = []
-    while len(propositions) < 4:
-        gen = random.choice(group)
-        propositions.append(gen())
-    # Decide which are true
+    # Chọn 1 nhóm mapping trong phần A, lấy 1 mệnh đề từ nhóm đó
+    selected_group = random.choice(PART_A_GROUPS)
+    primary_gen = random.choice(selected_group)
+    # Tạo pool còn lại: tất cả generator của phần A trừ nhóm đã chọn
+    all_gens: List = []
+    for grp in PART_A_GROUPS:
+        for g in grp:
+            all_gens.append(g)
+    # Loại bỏ các generator thuộc nhóm đã chọn
+    remaining_pool = [g for g in all_gens if g not in selected_group]
+    # Lấy 3 generator khác nhau từ remaining_pool (nếu thiếu thì cho phép lặp)
+    if len(remaining_pool) >= 3:
+        other_gens = random.sample(remaining_pool, 3)
+    else:
+        other_gens = [random.choice(remaining_pool) for _ in range(3)] if remaining_pool else [primary_gen]*3
+    selected_gens = [primary_gen] + other_gens
+    # Sinh 4 mệnh đề
+    propositions: List[Dict[str, str]] = [gen() for gen in selected_gens]
+    # Gán ngẫu nhiên mệnh đề đúng
     num_true = random.randint(1, 4)
     true_indices = set(random.sample(range(4), num_true))
     option_labels = ['a', 'b', 'c', 'd']

--- a/src/plane_true_false_part_A.py
+++ b/src/plane_true_false_part_A.py
@@ -1,0 +1,411 @@
+import math
+import random
+from typing import List, Tuple, Dict
+
+# Utilities
+
+def gcd(a: int, b: int) -> int:
+    while b:
+        a, b = b, a % b
+    return abs(a)
+
+
+def simplify_fraction(numer: int, denom: int) -> Tuple[int, int]:
+    if denom == 0:
+        return (numer, denom)
+    g = gcd(numer, denom)
+    numer //= g
+    denom //= g
+    if denom < 0:
+        numer = -numer
+        denom = -denom
+    return numer, denom
+
+
+def format_signed(value: int) -> str:
+    return f"+ {abs(value)}" if value > 0 else (f"- {abs(value)}" if value < 0 else "+ 0")
+
+
+def format_plane_equation(a: int, b: int, c: int, d: int) -> str:
+    parts: List[str] = []
+    # ax
+    if a == 1:
+        parts.append("x")
+    elif a == -1:
+        parts.append("-x")
+    elif a != 0:
+        parts.append(f"{a}x")
+    # by
+    if b != 0:
+        if parts:
+            if b == 1:
+                parts.append("+ y")
+            elif b == -1:
+                parts.append("- y")
+            elif b > 0:
+                parts.append(f"+ {b}y")
+            else:
+                parts.append(f"- {abs(b)}y")
+        else:
+            if b == 1:
+                parts.append("y")
+            elif b == -1:
+                parts.append("-y")
+            else:
+                parts.append(f"{b}y")
+    # cz
+    if c != 0:
+        if parts:
+            if c == 1:
+                parts.append("+ z")
+            elif c == -1:
+                parts.append("- z")
+            elif c > 0:
+                parts.append(f"+ {c}z")
+            else:
+                parts.append(f"- {abs(c)}z")
+        else:
+            if c == 1:
+                parts.append("z")
+            elif c == -1:
+                parts.append("-z")
+            else:
+                parts.append(f"{c}z")
+    # d
+    if d != 0:
+        if d > 0 and parts:
+            parts.append(f"+ {d}")
+        else:
+            parts.append(str(d))
+    if not parts:
+        parts.append("0")
+    return " ".join(parts) + " = 0"
+
+
+def format_point(pt: Tuple[int, int, int]) -> str:
+    return f"({pt[0]};{pt[1]};{pt[2]})"
+
+
+def are_collinear(v: Tuple[int, int, int], w: Tuple[int, int, int]) -> bool:
+    x1, y1, z1 = v
+    x2, y2, z2 = w
+    return (x1 * y2 == y1 * x2) and (x1 * z2 == z1 * x2) and (y1 * z2 == z1 * y2)
+
+
+def dot(v: Tuple[int, int, int], w: Tuple[int, int, int]) -> int:
+    return v[0]*w[0] + v[1]*w[1] + v[2]*w[2]
+
+
+def cross(u: Tuple[int, int, int], v: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    return (
+        u[1]*v[2] - u[2]*v[1],
+        u[2]*v[0] - u[0]*v[2],
+        u[0]*v[1] - u[1]*v[0]
+    )
+
+
+def point_plane_distance(a: int, b: int, c: int, d: int, P: Tuple[int, int, int]) -> Tuple[int, int]:
+    numer = abs(a*P[0] + b*P[1] + c*P[2] + d)
+    denom = int(math.isqrt(a*a + b*b + c*c))
+    # Keep radical if not perfect square; we will indicate as numerator/sqrt(norm_sq)
+    norm_sq = a*a + b*b + c*c
+    return numer, norm_sq
+
+
+def format_distance(numer: int, norm_sq: int) -> str:
+    # returns LaTeX like \dfrac{numer}{\sqrt{norm_sq}}
+    if norm_sq == 0:
+        return "0"
+    return f"\\dfrac{{{numer}}}{{\\sqrt{{{norm_sq}}}}}"
+
+
+# Proposition generators for Part A
+
+# Group: Ví dụ 4,5 (distance point-plane) + Câu 7 (reflection => AB = 2*distance)
+
+def prop_point_plane_distance() -> Dict[str, str]:
+    # Generate random plane and point
+    a = random.choice([v for v in range(-5, 6) if v != 0])
+    b = random.randint(-5, 5)
+    c = random.randint(-5, 5)
+    if a == 0 and b == 0 and c == 0:
+        a = 1
+    d = random.randint(-8, 8)
+    P = (random.randint(-4, 4), random.randint(-4, 4), random.randint(-4, 4))
+    numer, norm_sq = point_plane_distance(a, b, c, d, P)
+    true_text = f"Khoảng cách từ điểm A{format_point(P)} đến mặt phẳng (P): {format_plane_equation(a,b,c,d)} bằng $ {format_distance(numer, norm_sq)} $."
+    # false: tweak numerator by ±1..3 (ensure different)
+    delta = random.choice([1, 2, 3])
+    false_numer = numer + delta if numer != 0 else numer + 2
+    false_text = f"Khoảng cách từ điểm A{format_point(P)} đến mặt phẳng (P): {format_plane_equation(a,b,c,d)} bằng $ {format_distance(false_numer, norm_sq)} $."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_reflection_segment_length() -> Dict[str, str]:
+    # AB length for reflection across plane equals 2 * distance(A, plane)
+    a = random.choice([v for v in range(-4, 5) if v != 0])
+    b = random.randint(-4, 4)
+    c = random.randint(-4, 4)
+    if a == 0 and b == 0 and c == 0:
+        b = 1
+    d = random.randint(-6, 6)
+    A = (random.randint(-3, 3), random.randint(-3, 3), random.randint(-3, 3))
+    numer, norm_sq = point_plane_distance(a, b, c, d, A)
+    # AB = 2 * numer / sqrt(norm_sq)
+    true_text = f"Gọi B là điểm đối xứng của A{format_point(A)} qua mặt phẳng (P): {format_plane_equation(a,b,c,d)}. Khi đó độ dài $AB$ bằng $ {format_distance(2*numer, norm_sq)} $."
+    # false: tweak numerator
+    delta = random.choice([1, 2])
+    false_text = f"Gọi B là điểm đối xứng của A{format_point(A)} qua mặt phẳng (P): {format_plane_equation(a,b,c,d)}. Khi đó độ dài $AB$ bằng $ {format_distance(2*numer + delta, norm_sq)} $."
+    return {"true": true_text, "false": false_text}
+
+# Group: Ví dụ 3 (point on plane) - Câu 4 (m-parameter point on plane)
+
+def prop_point_on_plane_membership() -> Dict[str, str]:
+    a = random.choice([v for v in range(-4, 5) if v != 0])
+    b = random.randint(-4, 4)
+    c = random.randint(-4, 4)
+    d = random.randint(-6, 6)
+    # Create a point on plane
+    # Choose x,y then solve for z if c != 0, else adjust differently
+    x = random.randint(-3, 3)
+    y = random.randint(-3, 3)
+    if c == 0:
+        # ensure a*x + b*y + d = 0
+        z = random.randint(-3, 3)
+        d = -(a*x + b*y + c*z)
+    else:
+        rhs = -(a*x + b*y + d)
+        # ensure divisible for integer z sometimes; otherwise accept fractional but we keep integer
+        z = rhs // c
+        d = -(a*x + b*y + c*z)
+    P = (x, y, z)
+    true_text = f"Điểm M{format_point(P)} thuộc mặt phẳng (P): {format_plane_equation(a,b,c,d)}."
+    # false: modify one coordinate
+    Pf = (P[0] + random.choice([-1, 1]), P[1], P[2])
+    false_text = f"Điểm M{format_point(Pf)} thuộc mặt phẳng (P): {format_plane_equation(a,b,c,d)}."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_point_with_m_on_plane() -> Dict[str, str]:
+    # Point A(m; m-1; 1+2m) in plane ax+by+cz+d=0 -> find m value. We convert to T/F: with given m value, statement true/false
+    a = random.choice([v for v in range(-3, 4) if v != 0])
+    b = random.randint(-3, 3)
+    c = random.randint(-3, 3)
+    d = random.randint(-6, 6)
+    # Define point pattern like in tex
+    # Compute m solving a*m + b*(m-1) + c*(1+2m) + d = 0
+    coeff_m = a + b + 2*c
+    const_term = -b + c + d
+    # Ensure solvable (coeff_m != 0)
+    if coeff_m == 0:
+        coeff_m = 1
+    m_true = -const_term / coeff_m
+    # Prefer integer m
+    if abs(m_true - round(m_true)) < 1e-9:
+        m_display = str(int(round(m_true)))
+    else:
+        # format as fraction p/q
+        from fractions import Fraction
+        frac = Fraction(-const_term, coeff_m)
+        m_display = f"\\frac{{{frac.numerator}}}{{{frac.denominator}}}"
+    true_text = f"Với $m = {m_display}$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): {format_plane_equation(a,b,c,d)}."
+    # false: tweak m by +1
+    if isinstance(m_true, float) and abs(m_true - round(m_true)) < 1e-9:
+        m_false_display = str(int(round(m_true)) + random.choice([1, -1]))
+    else:
+        m_false_display = "0" if m_display != "0" else "1"
+    false_text = f"Với $m = {m_false_display}$, điểm $A(m;\, m-1;\, 1+2m)$ thuộc mặt phẳng (P): {format_plane_equation(a,b,c,d)}."
+    return {"true": true_text, "false": false_text}
+
+# Group: Ví dụ 7 (distance constraint) - Câu 12 (equal distances)
+
+def prop_equal_distance_to_plane_and_point_on_Oz() -> Dict[str, str]:
+    # Given plane ax+by+cz+d=0, point A(xa,ya,za). Find M on Oz: (0,0,k) such that d(M,plane) = d(M,A)
+    a = random.choice([v for v in range(-4, 5) if v != 0])
+    b = random.randint(-4, 4)
+    c = random.choice([v for v in range(-4, 5) if v != 0])
+    d = random.randint(-6, 6)
+    A = (random.randint(-3, 3), random.randint(-3, 3), random.randint(-3, 3))
+    # Distance to plane: |a*0 + b*0 + c*k + d| / sqrt(norm_sq) = |c*k + d| / sqrt(norm_sq)
+    # Distance to A: sqrt((0-xa)^2 + (0-ya)^2 + (k-za)^2)
+    # Equate squares: (c*k + d)^2 / (a^2 + b^2 + c^2) = xa^2 + ya^2 + (k - za)^2
+    norm_sq = a*a + b*b + c*c
+    xa2 = A[0]*A[0]
+    ya2 = A[1]*A[1]
+    za = A[2]
+    # (c*k + d)^2 = norm_sq*(xa^2 + ya^2 + (k - za)^2)
+    # Expand: c^2 k^2 + 2cd k + d^2 = norm_sq*(xa^2 + ya^2 + k^2 - 2za k + za^2)
+    # Bring to one side: (c^2 - norm_sq)k^2 + (2cd + 2 norm_sq za)k + (d^2 - norm_sq*(xa^2 + ya^2 + za^2)) = 0
+    A2 = c*c - norm_sq
+    B2 = 2*c*d + 2*norm_sq*za
+    C2 = d*d - norm_sq*(xa2 + ya2 + za*za)
+    # Solve quadratic; pick an integer-ish root if possible
+    disc = B2*B2 - 4*A2*C2
+    k_true: float
+    if A2 == 0:
+        # Linear case
+        if B2 == 0:
+            k_true = 0.0
+        else:
+            k_true = -C2 / B2
+    else:
+        if disc < 0:
+            k_true = 0.0
+        else:
+            sqrt_disc = math.sqrt(disc)
+            k1 = (-B2 + sqrt_disc) / (2*A2)
+            k2 = (-B2 - sqrt_disc) / (2*A2)
+            k_true = k1 if abs(k1) <= abs(k2) else k2
+    # Format
+    k_disp = f"{k_true:.2f}" if abs(k_true - round(k_true)) > 1e-9 else str(int(round(k_true)))
+    true_text = f"Tồn tại điểm $M(0;0;{k_disp})$ sao cho $d(M,(P)) = d(M,A)$ với $A{format_point(A)}$ và $(P): {format_plane_equation(a,b,c,d)}$."
+    k_false = (float(k_true) + random.choice([-1.0, 1.0, 2.0])) if isinstance(k_true, float) else (k_true + 1)
+    k_false_disp = f"{k_false:.2f}" if abs(k_false - round(k_false)) > 1e-9 else str(int(round(k_false)))
+    false_text = f"Tồn tại điểm $M(0;0;{k_false_disp})$ sao cho $d(M,(P)) = d(M,A)$ với $A{format_point(A)}$ và $(P): {format_plane_equation(a,b,c,d)}$."
+    return {"true": true_text, "false": false_text}
+
+# Group: Ví dụ 8 (angle between planes) - Câu 14 (angle with Oxy)
+
+def prop_angle_between_planes() -> Dict[str, str]:
+    # Angle between planes P: a1x+b1y+c1z+d1=0 and Q: a2x+b2y+c2z+d2=0
+    a1, b1, c1 = random.choice([v for v in range(-3, 4) if v != 0]), random.randint(-3, 3), random.randint(-3, 3)
+    a2, b2, c2 = random.choice([v for v in range(-3, 4) if v != 0]), random.randint(-3, 3), random.randint(-3, 3)
+    d1, d2 = random.randint(-6, 6), random.randint(-6, 6)
+    n1 = (a1, b1, c1)
+    n2 = (a2, b2, c2)
+    num = abs(dot(n1, n2))
+    den = math.sqrt((a1*a1 + b1*b1 + c1*c1) * (a2*a2 + b2*b2 + c2*c2))
+    cos_val = min(1.0, max(0.0, num / den if den != 0 else 0.0))
+    angle_deg = math.degrees(math.acos(cos_val))
+    angle_disp = f"{angle_deg:.0f}^\\circ"
+    true_text = f"Góc giữa hai mặt phẳng $(P): {format_plane_equation(a1,b1,c1,d1)}$ và $(Q): {format_plane_equation(a2,b2,c2,d2)}$ bằng $ {angle_disp} $."
+    # false: tweak by 15 degrees
+    false_angle = max(0, int(round(angle_deg)) + random.choice([-30, -15, 15, 30]))
+    false_text = f"Góc giữa hai mặt phẳng $(P): {format_plane_equation(a1,b1,c1,d1)}$ và $(Q): {format_plane_equation(a2,b2,c2,d2)}$ bằng $ {false_angle}^\\circ $."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_angle_plane_with_Oxy() -> Dict[str, str]:
+    # Angle between plane P and Oxy is angle between normals and (0,0,1)
+    a, b = random.randint(-3, 3), random.randint(-3, 3)
+    c = random.choice([v for v in range(-3, 4) if v != 0])
+    d = random.randint(-6, 6)
+    n = (a, b, c)
+    num = abs(c)
+    den = math.sqrt(a*a + b*b + c*c)
+    cos_val = min(1.0, max(0.0, num / den if den != 0 else 0.0))
+    angle_deg = math.degrees(math.acos(cos_val))
+    angle_disp = f"{angle_deg:.0f}^\\circ"
+    true_text = f"Góc giữa mặt phẳng $(P): {format_plane_equation(a,b,c,d)}$ và mặt phẳng $(Oxy)$ bằng $ {angle_disp} $."
+    false_angle = max(0, int(round(angle_deg)) + random.choice([-30, -15, 15, 30]))
+    false_text = f"Góc giữa mặt phẳng $(P): {format_plane_equation(a,b,c,d)}$ và mặt phẳng $(Oxy)$ bằng $ {false_angle}^\\circ $."
+    return {"true": true_text, "false": false_text}
+
+# Group: Ví dụ 9 (parallel planes), Câu 16 (intersect), Câu 17 (perpendicular)
+
+def prop_planes_parallel_with_params_sum() -> Dict[str, str]:
+    # Build two planes with normals proportional: (2,1,m) and (1,n,2) like in tex style
+    t = random.choice([1, 2, 3])
+    m = 2 * t  # ensure integer
+    n = 1 * t
+    # Planes (P): 2x + y + m z + p = 0 and (Q): x + n y + 2z + q = 0 (constants irrelevant)
+    p, q = random.randint(-5, 5), random.randint(-5, 5)
+    true_sum = m + n
+    true_text = f"Cho $(P): 2x + y + {m}z {format_signed(p)} = 0$ và $(Q): x + {n}y + 2z {format_signed(q)} = 0$ song song nhau. Khi đó $m + n = {true_sum}$."
+    false_text = f"Cho $(P): 2x + y + {m}z {format_signed(p)} = 0$ và $(Q): x + {n}y + 2z {format_signed(q)} = 0$ song song nhau. Khi đó $m + n = {true_sum + random.choice([-2,-1,1,2])}$."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_planes_intersect_condition_m() -> Dict[str, str]:
+    # (P): 2x+2y - z = 0 and (Q): x + y + m z + 1 = 0 intersect iff normals not parallel
+    m_true = random.choice([v for v in range(-4, 5) if v != -0.5])
+    true_text = f"Hai mặt phẳng $(P): 2x + 2y - z = 0$ và $(Q): x + y + {m_true}z + 1 = 0$ cắt nhau."
+    false_text = f"Hai mặt phẳng $(P): 2x + 2y - z = 0$ và $(Q): x + y - \frac{1}{2}z + 1 = 0$ cắt nhau."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_planes_perpendicular_condition_m() -> Dict[str, str]:
+    # (alpha): m^2 x - y + (m^2 - 2) z + 2 = 0 and (beta): 2x + m^2 y - 2z + 1 = 0 perpendicular when dot(n1,n2)=0
+    m = random.choice([1, 2, 3])
+    n1 = (m*m, -1, m*m - 2)
+    n2 = (2, m*m, -2)
+    is_perp = (dot(n1, n2) == 0)
+    # Build true by picking m that satisfies
+    if not is_perp:
+        # pick m=1 or 2 which usually works for the tex examples
+        m = 1
+    true_text = f"Hai mặt phẳng $(\alpha): {m*m}x - y + {(m*m - 2)}z + 2 = 0$ và $(\beta): 2x + {m*m}y - 2z + 1 = 0$ vuông góc."
+    # false with m+1
+    mf = m + 1
+    false_text = f"Hai mặt phẳng $(\alpha): {mf*mf}x - y + {(mf*mf - 2)}z + 2 = 0$ và $(\beta): 2x + {mf*mf}y - 2z + 1 = 0$ vuông góc."
+    return {"true": true_text, "false": false_text}
+
+
+# Registry of proposition groups for Part A
+PART_A_GROUPS: List[List] = [
+    # Ví dụ 4,5 + Câu 7
+    [prop_point_plane_distance, prop_reflection_segment_length],
+    # Ví dụ 3 - Câu 4
+    [prop_point_on_plane_membership, prop_point_with_m_on_plane],
+    # Ví dụ 7 - Câu 12
+    [prop_equal_distance_to_plane_and_point_on_Oz],
+    # Ví dụ 8 - Câu 14
+    [prop_angle_between_planes, prop_angle_plane_with_Oxy],
+    # Ví dụ 9 - Câu 16 - Câu 17
+    [prop_planes_parallel_with_params_sum, prop_planes_intersect_condition_m, prop_planes_perpendicular_condition_m],
+]
+
+
+def generate_question(question_number: int) -> str:
+    # Pick a group randomly and sample four propositions from it (allow repeats of type with different params)
+    group = random.choice(PART_A_GROUPS)
+    propositions: List[Dict[str, str]] = []
+    while len(propositions) < 4:
+        gen = random.choice(group)
+        propositions.append(gen())
+    # Decide which are true
+    num_true = random.randint(1, 4)
+    true_indices = set(random.sample(range(4), num_true))
+    option_labels = ['a', 'b', 'c', 'd']
+    content = f"Câu {question_number}: Chọn các mệnh đề đúng.\n\n"
+    for i in range(4):
+        text = propositions[i]['true'] if i in true_indices else propositions[i]['false']
+        marker = '*' if i in true_indices else ''
+        content += f"{marker}{option_labels[i]}) {text}\n\n"
+    return content
+
+
+def create_latex_document(questions: List[str], title: str = "Các bài toán về các thông số liên quan - Đúng/Sai") -> str:
+    latex = (
+        "\\documentclass[a4paper,12pt]{article}\n"
+        "\\usepackage{amsmath,amssymb}\n"
+        "\\usepackage{geometry}\n"
+        "\\geometry{a4paper, margin=1in}\n"
+        "\\usepackage{polyglossia}\n"
+        "\\setmainlanguage{vietnamese}\n"
+        "\\setmainfont{Times New Roman}\n"
+        "\\begin{document}\n\n"
+        f"\\section*{{{title}}}\n\n"
+    )
+    latex += "\n\n".join(questions)
+    latex += "\n\n\\end{document}"
+    return latex
+
+
+def main():
+    import sys
+    try:
+        num_questions = int(sys.argv[1]) if len(sys.argv) > 1 else 5
+    except Exception:
+        num_questions = 5
+    random.seed()
+    questions = [generate_question(i+1) for i in range(num_questions)]
+    tex = create_latex_document(questions)
+    out = "plane_true_false_part_A.tex"
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(tex)
+    print(f"Generated {out} with {len(questions)} question(s). Compile with XeLaTeX.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/plane_true_false_part_B.py
+++ b/src/plane_true_false_part_B.py
@@ -1,0 +1,183 @@
+import random
+from typing import List, Tuple, Dict
+
+# Simple formatters
+
+def format_point(pt: Tuple[int, int, int]) -> str:
+    return f"({pt[0]};{pt[1]};{pt[2]})"
+
+
+def format_vec(v: Tuple[int, int, int]) -> str:
+    return f"({v[0]};{v[1]};{v[2]})"
+
+
+def format_plane_equation(a: int, b: int, c: int, d: int) -> str:
+    parts: List[str] = []
+    if a == 1:
+        parts.append("x")
+    elif a == -1:
+        parts.append("-x")
+    elif a != 0:
+        parts.append(f"{a}x")
+    if b != 0:
+        if parts:
+            if b == 1:
+                parts.append("+ y")
+            elif b == -1:
+                parts.append("- y")
+            elif b > 0:
+                parts.append(f"+ {b}y")
+            else:
+                parts.append(f"- {abs(b)}y")
+        else:
+            if b == 1:
+                parts.append("y")
+            elif b == -1:
+                parts.append("-y")
+            else:
+                parts.append(f"{b}y")
+    if c != 0:
+        if parts:
+            if c == 1:
+                parts.append("+ z")
+            elif c == -1:
+                parts.append("- z")
+            elif c > 0:
+                parts.append(f"+ {c}z")
+            else:
+                parts.append(f"- {abs(c)}z")
+        else:
+            if c == 1:
+                parts.append("z")
+            elif c == -1:
+                parts.append("-z")
+            else:
+                parts.append(f"{c}z")
+    if d != 0:
+        if d > 0 and parts:
+            parts.append(f"+ {d}")
+        else:
+            parts.append(str(d))
+    if not parts:
+        parts.append("0")
+    return " ".join(parts) + " = 0"
+
+# Vector/plane helpers
+
+def cross(u: Tuple[int, int, int], v: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    return (u[1]*v[2] - u[2]*v[1], u[2]*v[0] - u[0]*v[2], u[0]*v[1] - u[1]*v[0])
+
+
+def subtract(p: Tuple[int, int, int], q: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    return (p[0]-q[0], p[1]-q[1], p[2]-q[2])
+
+# Propositions (Part B)
+
+# Ví dụ 21 - Câu 16 (phần B): planes through 3 points and (ABC) from projections
+
+def prop_plane_through_three_points() -> Dict[str, str]:
+    A = (1, 0, 0)
+    B = (0, -2, 0)
+    C = (0, 0, 3)
+    AB = subtract(B, A)
+    AC = subtract(C, A)
+    n = cross(AB, AC)
+    a, b, c = n
+    d = -(a*A[0] + b*A[1] + c*A[2])
+    true_text = f"Phương trình mặt phẳng qua A{format_point(A)}, B{format_point(B)}, C{format_point(C)} là $(P): {format_plane_equation(a,b,c,d)}$."
+    # false: tweak d by ±1
+    false_text = f"Phương trình mặt phẳng qua A{format_point(A)}, B{format_point(B)}, C{format_point(C)} là $(P): {format_plane_equation(a,b,c,d+1)}$."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_plane_from_projections_ABC() -> Dict[str, str]:
+    # Given M(1,2,3) -> projections give A(1,0,0), B(0,2,0), C(0,0,3) and plane x/1 + y/2 + z/3 = 1 -> 6x+3y+2z-6=0
+    M = (1, 2, 3)
+    A, B, C = (M[0], 0, 0), (0, M[1], 0), (0, 0, M[2])
+    true_text = "Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $6x+3y+2z-6=0$."
+    false_text = "Với điểm M(1;2;3), gọi A, B, C lần lượt là hình chiếu của M trên các trục tọa độ. Khi đó phương trình mặt phẳng (ABC) là $2x+3y+6z-6=0$."
+    return {"true": true_text, "false": false_text}
+
+# Ví dụ 22 - Câu 18: parallel with (ABC) from given M
+
+def prop_parallel_to_ABC_from_M() -> Dict[str, str]:
+    M = (-3, 2, 4)
+    # (ABC): x/|xM| + y/|yM| + z/|zM| = 1 -> 4x - 6y - 3z + 12 = 0 (as in tex)
+    true_text = "Cho điểm M(-3;2;4). Mặt phẳng song song với (ABC) (ABC từ hình chiếu của M) có phương trình $4x-6y-3z+12=0$."
+    false_text = "Cho điểm M(-3;2;4). Mặt phẳng song song với (ABC) có phương trình $3x-6y-4z+12=0$."
+    return {"true": true_text, "false": false_text}
+
+# Ví dụ 25 - Câu 23 - Câu 24: minimal volume and related optimization forms
+
+def prop_min_volume_plane_through_M() -> Dict[str, str]:
+    # For M(1,2,3), min volume plane through M cutting axes gives x/1 + y/2 + z/3 = 1 -> 6x+3y+2z-6=0
+    M = (1, 2, 3)
+    true_text = "Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+2z-18=0$."
+    false_text = "Mặt phẳng đi qua M(1;2;3) cắt ba trục tọa độ sao cho thể tích tứ diện OABC nhỏ nhất có phương trình $6x+3y+3z-21=0$."
+    return {"true": true_text, "false": false_text}
+
+
+def prop_min_sum_inverse_squares() -> Dict[str, str]:
+    # Shape-only statement consistent with tex style
+    true_text = "Với M(1;2;3), mặt phẳng (P) để $T=\\dfrac{1}{OA^2}+\\dfrac{1}{OB^2}+\\dfrac{1}{OC^2}$ nhỏ nhất có dạng $x+ay+bz+c=0$."
+    false_text = "Với M(1;2;3), mặt phẳng (P) để $T$ nhỏ nhất có dạng $ax+by+cz+d=0$ với $a=b=c=0$."
+    return {"true": true_text, "false": false_text}
+
+# Pool/group registry for Part B
+PART_B_GROUPS: List[List] = [
+    [prop_plane_through_three_points, prop_plane_from_projections_ABC],  # Ví dụ 21 - Câu 16 (phần B)
+    [prop_parallel_to_ABC_from_M],                                       # Ví dụ 22 - Câu 18
+    [prop_min_volume_plane_through_M, prop_min_sum_inverse_squares],     # Ví dụ 25 - Câu 23 - Câu 24
+]
+
+
+def generate_question(question_number: int) -> str:
+    group = random.choice(PART_B_GROUPS)
+    propositions: List[Dict[str, str]] = []
+    while len(propositions) < 4:
+        gen = random.choice(group)
+        propositions.append(gen())
+    num_true = random.randint(1, 4)
+    true_indices = set(random.sample(range(4), num_true))
+    option_labels = ['a', 'b', 'c', 'd']
+    content = f"Câu {question_number}: Chọn các mệnh đề đúng.\n\n"
+    for i in range(4):
+        text = propositions[i]['true'] if i in true_indices else propositions[i]['false']
+        marker = '*' if i in true_indices else ''
+        content += f"{marker}{option_labels[i]}) {text}\n\n"
+    return content
+
+
+def create_latex_document(questions: List[str], title: str = "Các bài toán về viết phương trình mặt phẳng - Đúng/Sai") -> str:
+    latex = (
+        "\\documentclass[a4paper,12pt]{article}\n"
+        "\\usepackage{amsmath,amssymb}\n"
+        "\\usepackage{geometry}\n"
+        "\\geometry{a4paper, margin=1in}\n"
+        "\\usepackage{polyglossia}\n"
+        "\\setmainlanguage{vietnamese}\n"
+        "\\setmainfont{Times New Roman}\n"
+        "\\begin{document}\n\n"
+        f"\\section*{{{title}}}\n\n"
+    )
+    latex += "\n\n".join(questions)
+    latex += "\n\n\\end{document}"
+    return latex
+
+
+def main():
+    import sys
+    try:
+        num_questions = int(sys.argv[1]) if len(sys.argv) > 1 else 5
+    except Exception:
+        num_questions = 5
+    questions = [generate_question(i+1) for i in range(num_questions)]
+    tex = create_latex_document(questions)
+    out = "plane_true_false_part_B.tex"
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(tex)
+    print(f"Generated {out} with {len(questions)} question(s). Compile with XeLaTeX.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/plane_true_false_part_B.py
+++ b/src/plane_true_false_part_B.py
@@ -132,11 +132,21 @@ PART_B_GROUPS: List[List] = [
 
 
 def generate_question(question_number: int) -> str:
-    group = random.choice(PART_B_GROUPS)
-    propositions: List[Dict[str, str]] = []
-    while len(propositions) < 4:
-        gen = random.choice(group)
-        propositions.append(gen())
+    # Chọn 1 nhóm mapping trong phần B, lấy 1 mệnh đề từ nhóm đó
+    selected_group = random.choice(PART_B_GROUPS)
+    primary_gen = random.choice(selected_group)
+    # Pool còn lại là tất cả generator của phần B trừ nhóm đã chọn
+    all_gens: List = []
+    for grp in PART_B_GROUPS:
+        for g in grp:
+            all_gens.append(g)
+    remaining_pool = [g for g in all_gens if g not in selected_group]
+    if len(remaining_pool) >= 3:
+        other_gens = random.sample(remaining_pool, 3)
+    else:
+        other_gens = [random.choice(remaining_pool) for _ in range(3)] if remaining_pool else [primary_gen]*3
+    selected_gens = [primary_gen] + other_gens
+    propositions: List[Dict[str, str]] = [gen() for gen in selected_gens]
     num_true = random.randint(1, 4)
     true_indices = set(random.sample(range(4), num_true))
     option_labels = ['a', 'b', 'c', 'd']

--- a/src/plane_true_false_part_C.py
+++ b/src/plane_true_false_part_C.py
@@ -152,11 +152,21 @@ PART_C_GROUPS: List[List] = [
 
 
 def generate_question(question_number: int) -> str:
-    group = random.choice(PART_C_GROUPS)
-    props: List[Dict[str, str]] = []
-    while len(props) < 4:
-        gen = random.choice(group)
-        props.append(gen())
+    # Chọn 1 nhóm mapping trong phần C, lấy 1 mệnh đề từ nhóm đó
+    selected_group = random.choice(PART_C_GROUPS)
+    primary_gen = random.choice(selected_group)
+    # Pool còn lại: tất cả generator của phần C trừ nhóm đã chọn
+    all_gens: List = []
+    for grp in PART_C_GROUPS:
+        for g in grp:
+            all_gens.append(g)
+    remaining_pool = [g for g in all_gens if g not in selected_group]
+    if len(remaining_pool) >= 3:
+        other_gens = random.sample(remaining_pool, 3)
+    else:
+        other_gens = [random.choice(remaining_pool) for _ in range(3)] if remaining_pool else [primary_gen]*3
+    selected_gens = [primary_gen] + other_gens
+    props: List[Dict[str, str]] = [gen() for gen in selected_gens]
     num_true = random.randint(1, 4)
     true_indices = set(random.sample(range(4), num_true))
     labels = ['a', 'b', 'c', 'd']

--- a/src/plane_true_false_part_C.py
+++ b/src/plane_true_false_part_C.py
@@ -1,0 +1,203 @@
+import math
+import random
+from typing import List, Tuple, Dict
+
+# Formatters
+
+def format_plane_equation(a: int, b: int, c: int, d: int) -> str:
+    parts: List[str] = []
+    if a == 1:
+        parts.append("x")
+    elif a == -1:
+        parts.append("-x")
+    elif a != 0:
+        parts.append(f"{a}x")
+    if b != 0:
+        if parts:
+            if b == 1:
+                parts.append("+ y")
+            elif b == -1:
+                parts.append("- y")
+            elif b > 0:
+                parts.append(f"+ {b}y")
+            else:
+                parts.append(f"- {abs(b)}y")
+        else:
+            if b == 1:
+                parts.append("y")
+            elif b == -1:
+                parts.append("-y")
+            else:
+                parts.append(f"{b}y")
+    if c != 0:
+        if parts:
+            if c == 1:
+                parts.append("+ z")
+            elif c == -1:
+                parts.append("- z")
+            elif c > 0:
+                parts.append(f"+ {c}z")
+            else:
+                parts.append(f"- {abs(c)}z")
+        else:
+            if c == 1:
+                parts.append("z")
+            elif c == -1:
+                parts.append("-z")
+            else:
+                parts.append(f"{c}z")
+    if d != 0:
+        if d > 0 and parts:
+            parts.append(f"+ {d}")
+        else:
+            parts.append(str(d))
+    if not parts:
+        parts.append("0")
+    return " ".join(parts) + " = 0"
+
+
+def format_point(pt: Tuple[int, int, int]) -> str:
+    return f"({pt[0]};{pt[1]};{pt[2]})"
+
+# Helpers
+
+def point_plane_distance_numer_normsq(a: int, b: int, c: int, d: int, P: Tuple[int, int, int]) -> Tuple[int, int]:
+    numer = abs(a*P[0] + b*P[1] + c*P[2] + d)
+    norm_sq = a*a + b*b + c*c
+    return numer, norm_sq
+
+
+def sphere_center_radius_from_eq(A: int, B: int, C: int, D: int) -> Tuple[Tuple[float, float, float], float]:
+    # x^2 + y^2 + z^2 + 2ux + 2vy + 2wz + D = 0 => center (-u, -v, -w), r^2 = u^2+v^2+w^2 - D
+    u, v, w = A/2.0, B/2.0, C/2.0
+    cx, cy, cz = -u, -v, -w
+    r_sq = u*u + v*v + w*w - D
+    r = math.sqrt(abs(r_sq))
+    return (cx, cy, cz), r
+
+# Propositions for Part C
+
+# Tangent plane at a point on sphere
+
+def prop_tangent_plane_at_point() -> Dict[str, str]:
+    # Sphere: (x-1)^2 + (y+1)^2 + (z-3)^2 = 9; point M(2,1,1) genericized
+    center = (random.randint(-2, 2), random.randint(-2, 2), random.randint(-2, 2))
+    r = random.choice([3, 4, 5])
+    # pick a point on sphere by offsetting along x
+    M = (center[0] + r, center[1], center[2])
+    # Tangent plane normal is vector CM
+    a, b, c = (M[0]-center[0], M[1]-center[1], M[2]-center[2])
+    d = -(a*M[0] + b*M[1] + c*M[2])
+    true_text = f"Mặt phẳng tiếp xúc với mặt cầu tâm I{format_point(center)} bán kính {r} tại M{format_point(M)} có phương trình $(P): {format_plane_equation(a,b,c,d)}$."
+    false_text = f"Mặt phẳng tiếp xúc với mặt cầu tâm I{format_point(center)} bán kính {r} tại M{format_point(M)} có phương trình $(P): {format_plane_equation(a,b,c,d+1)}$."
+    return {"true": true_text, "false": false_text}
+
+# Plane parallel to given plane and tangent to sphere
+
+def prop_plane_parallel_tangent_to_sphere() -> Dict[str, str]:
+    # Sphere general: x^2+y^2+z^2+2ux+2vy+2wz + D = 0
+    u, v, w = random.randint(-3, 3), random.randint(-3, 3), random.randint(-3, 3)
+    D = random.randint(-10, 5)
+    center = (-u, -v, -w)
+    r = math.sqrt(max(0.0, u*u + v*v + w*w - D))
+    # Given plane: ax+by+cz+d0=0, parallel planes: same (a,b,c) with different d
+    a, b, c = random.choice([1, 2, 3]), random.choice([1, 2]), random.choice([-2, -1, 1, 2])
+    d0 = random.randint(-10, 10)
+    # Distance from center to plane equals radius at tangency: |a*cx+b*cy+c*cz + d| / sqrt(a^2+b^2+c^2) = r
+    numer_c = abs(a*center[0] + b*center[1] + c*center[2])
+    norm = math.sqrt(a*a + b*b + c*c)
+    # d_true candidates: d = ±(r*norm) - (a*cx+b*cy+c*cz)
+    offset = r*norm
+    d_true = - (a*center[0] + b*center[1] + c*center[2]) + offset
+    d_false = d_true + random.choice([1, -1, 2, -2])
+    true_text = f"Tồn tại mặt phẳng $(Q)$ song song với $(P): {format_plane_equation(a,b,c,int(d0))}$ và tiếp xúc với mặt cầu $x^2+y^2+z^2+{2*u}x+{2*v}y+{2*w}z+{D}=0$ có dạng $(Q): {format_plane_equation(a,b,c,int(round(d_true)))}$."
+    false_text = f"$(Q): {format_plane_equation(a,b,c,int(round(d_false)))}$ cũng là mặt phẳng tiếp xúc như trên."
+    return {"true": true_text, "false": false_text}
+
+# Distance from center to plane equals radius
+
+def prop_radius_from_center_plane_distance() -> Dict[str, str]:
+    a, b, c = 4, 3, -2
+    d = 1
+    I = (0, -2, 1)
+    numer, norm_sq = point_plane_distance_numer_normsq(a, b, c, d, I)
+    true_text = f"Hình cầu tâm I{format_point(I)} tiếp xúc với mặt phẳng $(P): {format_plane_equation(a,b,c,d)}$ có bán kính $\\dfrac{{{numer}}}{{\\sqrt{{{norm_sq}}}}}$."
+    false_text = f"Hình cầu tâm I{format_point(I)} tiếp xúc với mặt phẳng $(P): {format_plane_equation(a,b,c,d)}$ có bán kính $\\dfrac{{{numer+1}}}{{\\sqrt{{{norm_sq}}}}}$."
+    return {"true": true_text, "false": false_text}
+
+# Non-intersection (no common point) condition between plane and sphere parameter m
+
+def prop_plane_sphere_no_intersection_param() -> Dict[str, str]:
+    # Sphere: (x+1)^2+(y-2)^2+(z-3)^2 = 25 -> x^2+y^2+z^2+2x-4y-6z-11=0
+    # Plane: 2x+y-2z+m=0; no intersection if distance from center > radius
+    center = (-1, 2, 3)
+    r = 5
+    a, b, c = 2, 1, -2
+    # distance |a*cx+b*cy+c*cz + m| / sqrt(a^2+b^2+c^2) > r => |a*cx+b*cy+c*cz + m| > r*norm
+    base = a*center[0] + b*center[1] + c*center[2]
+    norm = math.sqrt(a*a + b*b + c*c)
+    threshold = r*norm
+    # Choose m so that |base + m| > threshold
+    m_true = int(math.copysign(math.ceil(threshold) + random.randint(0, 3), random.choice([-1, 1]))) - base
+    true_text = f"Với $(P): 2x+y-2z+m=0$ và mặt cầu $(S): (x+1)^2+(y-2)^2+(z-3)^2=25$, khi $m$ đủ lớn về trị tuyệt đối thì $(P)$ và $(S)$ không có điểm chung."
+    false_text = f"Với $(P): 2x+y-2z+m=0$ và $(S)$ như trên, luôn tồn tại giao tuyến là đường tròn với mọi $m$."
+    return {"true": true_text, "false": false_text}
+
+PART_C_GROUPS: List[List] = [
+    [prop_tangent_plane_at_point],
+    [prop_plane_parallel_tangent_to_sphere],
+    [prop_radius_from_center_plane_distance],
+    [prop_plane_sphere_no_intersection_param],
+]
+
+
+def generate_question(question_number: int) -> str:
+    group = random.choice(PART_C_GROUPS)
+    props: List[Dict[str, str]] = []
+    while len(props) < 4:
+        gen = random.choice(group)
+        props.append(gen())
+    num_true = random.randint(1, 4)
+    true_indices = set(random.sample(range(4), num_true))
+    labels = ['a', 'b', 'c', 'd']
+    content = f"Câu {question_number}: Chọn các mệnh đề đúng.\n\n"
+    for i in range(4):
+        txt = props[i]['true'] if i in true_indices else props[i]['false']
+        mark = '*' if i in true_indices else ''
+        content += f"{mark}{labels[i]}) {txt}\n\n"
+    return content
+
+
+def create_latex_document(questions: List[str], title: str = "Tương giao mặt phẳng và mặt cầu - Đúng/Sai") -> str:
+    latex = (
+        "\\documentclass[a4paper,12pt]{article}\n"
+        "\\usepackage{amsmath,amssymb}\n"
+        "\\usepackage{geometry}\n"
+        "\\geometry{a4paper, margin=1in}\n"
+        "\\usepackage{polyglossia}\n"
+        "\\setmainlanguage{vietnamese}\n"
+        "\\setmainfont{Times New Roman}\n"
+        "\\begin{document}\n\n"
+        f"\\section*{{{title}}}\n\n"
+    )
+    latex += "\n\n".join(questions)
+    latex += "\n\n\\end{document}"
+    return latex
+
+
+def main():
+    import sys
+    try:
+        num_questions = int(sys.argv[1]) if len(sys.argv) > 1 else 5
+    except Exception:
+        num_questions = 5
+    qs = [generate_question(i+1) for i in range(num_questions)]
+    tex = create_latex_document(qs)
+    out = "plane_true_false_part_C.tex"
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(tex)
+    print(f"Generated {out} with {len(qs)} question(s). Compile with XeLaTeX.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add three new Python scripts to generate true/false geometry questions, split by topic, from existing LaTeX content.

---
<a href="https://cursor.com/background-agent?bcId=bc-01406548-eb55-444d-ab30-ad7e16ddd47e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01406548-eb55-444d-ab30-ad7e16ddd47e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

